### PR TITLE
chore: Update eslint-config-prettier version

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,13 +7,9 @@ module.exports = {
   extends: [
     '@nuxtjs/eslint-config-typescript',
     'prettier',
-    'prettier/standard',
-    'prettier/vue',
-    'prettier/flowtype',
     'plugin:prettier/recommended',
     'plugin:nuxt/recommended'
   ],
-  plugins: ['prettier'],
   rules: {
     'no-console': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
     'no-debugger': process.env.NODE_ENV === 'production' ? 'warn' : 'off',

--- a/package-lock.json
+++ b/package-lock.json
@@ -9953,13 +9953,10 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.12.0.tgz",
-      "integrity": "sha512-9jWPlFlgNwRUYVoujvWTQ1aMO8o6648r+K7qU7K5Jmkbyqav1fuEZC0COYpGBxyiAJb65Ra9hrmFx19xRGwXWw==",
-      "dev": true,
-      "requires": {
-        "get-stdin": "^6.0.0"
-      }
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.1.0.tgz",
+      "integrity": "sha512-oKMhGv3ihGbCIimCAjqkdzx2Q+jthoqnXSP+d86M9tptwugycmTFdVR4IpLgq2c4SHifbwO90z2fQ8/Aio73yw==",
+      "dev": true
     },
     "eslint-config-standard": {
       "version": "14.1.1",
@@ -11593,12 +11590,6 @@
       "requires": {
         "fs-memo": "^1.0.0"
       }
-    },
-    "get-stdin": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
-      "dev": true
     },
     "get-stream": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "babel-eslint": "^10.1.0",
     "babel-preset-vue": "^2.0.2",
     "eslint": "^7.10.0",
-    "eslint-config-prettier": "^6.12.0",
+    "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-nuxt": "^1.0.0",
     "eslint-plugin-prettier": "^3.1.4",
     "hard-source-webpack-plugin": "^0.13.1",


### PR DESCRIPTION
eslint-config-prettier 8버전 이후부터 prettier 하나로 끌 수 있다고해서 풀리퀘스트 남겨봅니다. 
https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21